### PR TITLE
Add Edelman response function

### DIFF
--- a/pastas_plugins/responses/rfunc_utils.py
+++ b/pastas_plugins/responses/rfunc_utils.py
@@ -30,3 +30,25 @@ def kraijenhoff_parameters(
     A = -N * L**2 / (2 * Ks * D) * (b**2 - (1 / 4))
     a = Sy * L**2 / (pi**2 * Ks * D)
     return A, a, b
+
+
+def exponential_parameters(c: float, Sy: float) -> tuple[float]:
+    """Get Pastas parameters for an Exponential response for a linear
+    reservoir system.
+
+    Parameters
+    ----------
+    c : float
+        The drainage resistance in days.
+    Sy : float
+        The specific yield of the aquifer [-].
+
+    Returns
+    -------
+    tuple[float]
+        A tuple containing the response parameters A and a.
+    """
+
+    A = c
+    a = c * Sy
+    return A, a

--- a/tests/test_responses.py
+++ b/tests/test_responses.py
@@ -1,6 +1,7 @@
 import numpy as np
+from pandas import DataFrame
 
-from pastas_plugins.responses.rfunc import Theis
+from pastas_plugins.responses.rfunc import Edelman, Theis
 
 
 def test_theis_init():
@@ -47,3 +48,51 @@ def test_theis_to_dict():
     assert data["class"] == "Theis"
     assert data["cutoff"] == theis.cutoff
     # assert data["nterms"] == theis.nterms
+
+
+def test_edelman_init():
+    cutoff = 0.999
+    rfunc = Edelman(cutoff=cutoff)
+    assert rfunc.cutoff == cutoff
+
+
+def test_edelman_get_init_parameters():
+    rfunc = Edelman()
+    params = rfunc.get_init_parameters("Edelman")
+    assert isinstance(params, DataFrame)
+    assert len(params) == 1
+    assert params.loc["Edelman_beta"]["initial"] == 1.0
+
+
+def test_edelman_get_tmax():
+    p = np.array([1.0])
+    cutoff = 0.999
+    rfunc = Edelman(cutoff=cutoff)
+    tmax = rfunc.get_tmax(p, cutoff=cutoff)
+    assert isinstance(tmax, float)
+
+
+def test_edelman_gain():
+    p = np.array([1.0])
+    rfunc = Edelman()
+    gain = rfunc.gain(p)
+    assert isinstance(gain, float)
+    assert gain == 1.0
+
+
+def test_edelman_impulse():
+    t = np.array([1.0, 2.0, 3.0])
+    p = np.array([1.0])
+    rfunc = Edelman()
+    impulse = rfunc.impulse(t, p)
+    assert isinstance(impulse, np.ndarray)
+    assert len(impulse) == len(t)
+
+
+def test_edelman_step():
+    p = np.array([1.0])
+    dt = 1.0
+    cutoff = 0.999
+    rfunc = Edelman(cutoff=cutoff)
+    step = rfunc.step(p, dt=dt, cutoff=cutoff)
+    assert isinstance(step, np.ndarray)


### PR DESCRIPTION
Edelman needs to be removed in future version of pastas and added to the plugins library. See Pastas issue [#475](https://github.com/pastas/pastas/issues/475)

The `exponential_parameters` function is useful for extracting the corresponding Pastas parameters for physically realistic systems, just as `kraijenhoff_parameters`.