### PR TITLE
Drop python 3.9 support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ maintainers = [
         { name = "M. Bakker", email = "markbak@gmail.com" },
 ]
 
-requires-python = ">= 3.9"
+requires-python = ">= 3.10"
 dependencies = ["pastas"]
 keywords = ["hydrology", "groundwater", "timeseries", "analysis"]
 classifiers = [
@@ -24,7 +24,6 @@ classifiers = [
         'Intended Audience :: Other Audience',
         'License :: OSI Approved :: MIT License',
         'Programming Language :: Python :: 3 :: Only',
-        'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',
         'Programming Language :: Python :: 3.12',
@@ -68,7 +67,7 @@ fix = true
 legacy_tox_ini = """
     [tox]
     requires = tox>=4
-    env_list = py{39,310,311,312}
+    env_list = py{310,311,312}
 
     [testenv:all]
     description = run all unit tests and obtain coverage


### PR DESCRIPTION
See #13 
Also, Pandas, NumPy, SciPy etc. don't support python 3.9 anymore. Pastas will also drop support soon I think, so might as well drop it now. 